### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Note that '·' above is not ASCII, but rather Unicode, the MIDDLE DOT character,
 
 The core engine of ```goat``` is accessible as a Go library package, for inclusion in specialized
 code of your own.
-The code implements a subset, and some extensions, of the ASCII diagram generation function of the browser-side Javascript in [Markdeep](http://casual-effects.com/markdeep/).
+The code implements a subset, and some extensions, of the ASCII diagram generation function of the browser-side Javascript in [Markdeep][].
 
 ### library Data Flow
 ![](./goat.svg)
@@ -224,9 +224,4 @@ source file [./goat.go](./goat.go).
 4. Composability of TXT not to be sacrificed -- only width-8 characters allowed.
 5. Per-platform support limited to a single widely-available fixed-pitch TXT font. 
 
-[@bep]: https://github.com/bep/goat/
-[@dmacvicar]: https://github.com/dmacvicar/goat
-[@sw46]: https://github.com/sw46/goat/
-[SVG]: https://en.wikipedia.org/wiki/Scalable_Vector_Graphics
-[markdeep.mini.js]: http://casual-effects.com/markdeep/
-[v0.93.0]: https://github.com/gohugoio/hugo/releases/tag/v0.93.0
+[Markdeep]: https://casual-effects.com/markdeep/

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -113,7 +113,7 @@ Note that '·' above is not ASCII, but rather Unicode, the MIDDLE DOT character,
 
 The core engine of ```goat``` is accessible as a Go library package, for inclusion in specialized
 code of your own.
-The code implements a subset, and some extensions, of the ASCII diagram generation function of the browser-side Javascript in [Markdeep](http://casual-effects.com/markdeep/).
+The code implements a subset, and some extensions, of the ASCII diagram generation function of the browser-side Javascript in [Markdeep][].
 
 ### library Data Flow
 ![]({{.Root}}/goat.svg)
@@ -129,9 +129,5 @@ source file [./goat.go](./goat.go).
 4. Composability of TXT not to be sacrificed -- only width-8 characters allowed.
 5. Per-platform support limited to a single widely-available fixed-pitch TXT font. 
 
-[@bep]: https://github.com/bep/goat/
-[@dmacvicar]: https://github.com/dmacvicar/goat
-[@sw46]: https://github.com/sw46/goat/
-[SVG]: https://en.wikipedia.org/wiki/Scalable_Vector_Graphics
-[markdeep.mini.js]: http://casual-effects.com/markdeep/
-[v0.93.0]: https://github.com/gohugoio/hugo/releases/tag/v0.93.0
+[Markdeep]: https://casual-effects.com/markdeep/
+

--- a/markdown_to_html.sh
+++ b/markdown_to_html.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-#  For local test of markdown generation, use a standalone Markdown-to-HTML processer.
+#  For local test of markdown generation, use a standalone Markdown-to-HTML processor.
 
 set -e
 #set -x


### PR DESCRIPTION
This PR fixes a typo and removes unused links from `README.md`. It also converts one link from `http` to `https` protocol.