### PR TITLE
Stop nesting <a> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,15 @@ when executed at the top of the cloned GoAT source tree, combines a text file co
 ```
 with the CSS content
 ```
-a.bold {
+.bold {
     goat-anchor-marks: "··";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "``";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "‗‗";  /*  -- resort to UTF-8 */
     text-decoration: underline;
 }
@@ -208,19 +208,19 @@ combines a text file containing
 ```
 with the CSS content
 ```
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }
@@ -239,7 +239,7 @@ For further details, see
 GoAT can add web links to text strings within your diagram.
 By appending to the GoAT command line above also a path to a CSS file containing this:
 ```
-a.underline_href {
+.underline_href {
     goat-anchor-marks: "__";
     goat-anchor-href: "https://www.worldometers.info/";
 }

--- a/ascii/_README/complicated.motley.svg
+++ b/ascii/_README/complicated.motley.svg
@@ -34,15 +34,15 @@
     }
   </style>
   <style type="text/css" source-text-origin="embed:style/ascii.css">
-a.bold {
+.bold {
     goat-anchor-marks: "··";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "``";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "‗‗";  /*  -- resort to UTF-8 */
     text-decoration: underline;
 }
@@ -337,20 +337,20 @@ circle.hollow {
     <path class="path" d="M 584,104 A 9,9 0 0,1 584,120"></path>
   </g>
   <g id='text'>
-  <a class='underline'>
+  <g class='underline'>
     <text x="64" y="20">A</text>
     <text x="72" y="20"> </text>
     <text x="80" y="20">B</text>
     <text x="88" y="20">o</text>
     <text x="96" y="20">x</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="200" y="68">R</text>
     <text x="208" y="68">o</text>
     <text x="216" y="68">u</text>
     <text x="224" y="68">n</text>
     <text x="232" y="68">d</text>
-</a>
+  </g>
     <text x="40" y="100">M</text>
     <text x="48" y="100">i</text>
     <text x="56" y="100">x</text>
@@ -415,7 +415,7 @@ circle.hollow {
     <text x="88" y="212">&gt;</text>
     <text x="104" y="212">b</text>
     <text x="112" y="212">)</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="440" y="212">C</text>
     <text x="448" y="212">u</text>
     <text x="456" y="212">r</text>
@@ -426,7 +426,7 @@ circle.hollow {
     <text x="504" y="212">i</text>
     <text x="512" y="212">n</text>
     <text x="520" y="212">e</text>
-</a>
+  </g>
     <text x="40" y="228">o</text>
     <text x="48" y="228">b</text>
     <text x="56" y="228">j</text>
@@ -446,14 +446,14 @@ circle.hollow {
     <text x="136" y="276">o</text>
     <text x="144" y="276">i</text>
     <text x="152" y="276">n</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="368" y="276">C</text>
     <text x="376" y="276">u</text>
     <text x="384" y="276">r</text>
     <text x="392" y="276">v</text>
     <text x="400" y="276">e</text>
     <text x="408" y="276">d</text>
-</a>
+  </g>
     <text x="360" y="292">V</text>
     <text x="368" y="292">e</text>
     <text x="376" y="292">r</text>
@@ -481,12 +481,12 @@ circle.hollow {
     <text x="568" y="324">'</text>
     <text x="456" y="340">A</text>
     <text x="496" y="340">B</text>
-  <a class='bold'>
+  <g class='bold'>
     <text x="536" y="340">b</text>
     <text x="544" y="340">o</text>
     <text x="552" y="340">l</text>
     <text x="560" y="340">d</text>
-</a>
+  </g>
     <text x="168" y="356">N</text>
     <text x="176" y="356">o</text>
     <text x="184" y="356">t</text>

--- a/ascii/_README/complicated.svg
+++ b/ascii/_README/complicated.svg
@@ -60,15 +60,15 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/ascii.css">
-a.bold {
+.bold {
     goat-anchor-marks: "··";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "``";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "‗‗";  /*  -- resort to UTF-8 */
     text-decoration: underline;
 }
@@ -363,20 +363,20 @@ circle.hollow {
     <path class="path" d="M 584,104 A 9,9 0 0,1 584,120"></path>
   </g>
   <g id='text'>
-  <a class='underline'>
+  <g class='underline'>
     <text x="64" y="20">A</text>
     <text x="72" y="20"> </text>
     <text x="80" y="20">B</text>
     <text x="88" y="20">o</text>
     <text x="96" y="20">x</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="200" y="68">R</text>
     <text x="208" y="68">o</text>
     <text x="216" y="68">u</text>
     <text x="224" y="68">n</text>
     <text x="232" y="68">d</text>
-</a>
+  </g>
     <text x="40" y="100">M</text>
     <text x="48" y="100">i</text>
     <text x="56" y="100">x</text>
@@ -441,7 +441,7 @@ circle.hollow {
     <text x="88" y="212">&gt;</text>
     <text x="104" y="212">b</text>
     <text x="112" y="212">)</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="440" y="212">C</text>
     <text x="448" y="212">u</text>
     <text x="456" y="212">r</text>
@@ -452,7 +452,7 @@ circle.hollow {
     <text x="504" y="212">i</text>
     <text x="512" y="212">n</text>
     <text x="520" y="212">e</text>
-</a>
+  </g>
     <text x="40" y="228">o</text>
     <text x="48" y="228">b</text>
     <text x="56" y="228">j</text>
@@ -472,14 +472,14 @@ circle.hollow {
     <text x="136" y="276">o</text>
     <text x="144" y="276">i</text>
     <text x="152" y="276">n</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="368" y="276">C</text>
     <text x="376" y="276">u</text>
     <text x="384" y="276">r</text>
     <text x="392" y="276">v</text>
     <text x="400" y="276">e</text>
     <text x="408" y="276">d</text>
-</a>
+  </g>
     <text x="360" y="292">V</text>
     <text x="368" y="292">e</text>
     <text x="376" y="292">r</text>
@@ -507,12 +507,12 @@ circle.hollow {
     <text x="568" y="324">'</text>
     <text x="456" y="340">A</text>
     <text x="496" y="340">B</text>
-  <a class='bold'>
+  <g class='bold'>
     <text x="536" y="340">b</text>
     <text x="544" y="340">o</text>
     <text x="552" y="340">l</text>
     <text x="560" y="340">d</text>
-</a>
+  </g>
     <text x="168" y="356">N</text>
     <text x="176" y="356">o</text>
     <text x="184" y="356">t</text>

--- a/ascii/_README/hello-world.styled.svg
+++ b/ascii/_README/hello-world.styled.svg
@@ -60,15 +60,15 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/ascii.css">
-a.bold {
+.bold {
     goat-anchor-marks: "··";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "``";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "‗‗";  /*  -- resort to UTF-8 */
     text-decoration: underline;
 }
@@ -97,21 +97,21 @@ a.underline {
   <g id='bridges'>
   </g>
   <g id='text'>
-  <a class='italic'>
+  <g class='italic'>
     <text x="72" y="20">H</text>
     <text x="80" y="20">e</text>
     <text x="88" y="20">l</text>
     <text x="96" y="20">l</text>
     <text x="104" y="20">o</text>
     <text x="112" y="20">,</text>
-  <a class='underline'>
+  <g class='underline'>
     <text x="128" y="20">w</text>
     <text x="136" y="20">o</text>
     <text x="144" y="20">r</text>
     <text x="152" y="20">l</text>
     <text x="160" y="20">d</text>
-</a>
-</a>
+  </g>
+  </g>
 </g>
 </g>
 </svg>

--- a/cmd/goat/parseargs.go
+++ b/cmd/goat/parseargs.go
@@ -152,7 +152,7 @@ Input is a UTF-8 encoded byte stream; output is a single <svg> element.
 			err = svg.ParseCss(markBindingMap, newCss)
 			if err != nil {
 				log.Fatalf(`
-Could not parse filename '%s',
+Could not parse file '%s',
    err = %v`,
 					cssFilename, err)
 			}

--- a/css/style/ascii.css
+++ b/css/style/ascii.css
@@ -1,12 +1,12 @@
-a.bold {
+.bold {
     goat-anchor-marks: "··";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "``";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "‗‗";  /*  -- resort to UTF-8 */
     text-decoration: underline;
 }

--- a/css/style/utf8.css
+++ b/css/style/utf8.css
@@ -1,16 +1,16 @@
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }

--- a/svg/config.go
+++ b/svg/config.go
@@ -129,12 +129,13 @@ func ParseCss(bindings MarkBindingMap, cssBytes []byte) error {
 				markBinding.HRef = lexDeclaration(cssTokens)
 			}
 			// Fatal error if a GoAT-specific property is found
-			// inside a RuleSet whose CSS selector list is not simply names of anchor classes.
+			// inside a RuleSet whose CSS selector list is not names of classes, with or without a prepended element tag.
 			if len(markBinding.ClassNames) == 0 {
 				// XX  At this point, markBinding.markpair[2] is not yet initialized.
 				return fmt.Errorf(
-					"GoAT-specific properties found, but no a.CLASSNAME selectors for the RuleSet:\n\t%#v",
-					markBinding)
+					`GoAT-specific properties found, but no .CLASSNAME selectors for the RuleSet:
+	%s`,
+					markBinding.String())
 			}
 		}
 	}
@@ -172,11 +173,11 @@ func lexDeclaration(cssTokens []css.Token) (tokenStr string) {
 }
 
 func beginRuleSet(parser *css.Parser) (kb markBinding) {
-	var isAnchorClass bool
+	var isClass bool
 
 	// Consume the CSS selector list.
 	//   https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Selector_list
-	lastTokenStr := ""
+	// lastTokenStr := ""
 	for _, token := range parser.Values() {
 		tokenStr := string(token.Data)
 		if DUMP_CSS {
@@ -192,17 +193,17 @@ func beginRuleSet(parser *css.Parser) (kb markBinding) {
 			kb._idName = tokenStr[1:]
 		case css.DelimToken:
 			// The initial '.' of a class rule hits this.
-			if lastTokenStr == "a" && tokenStr == "." {
-				isAnchorClass = true
+			if tokenStr == "." {
+				isClass = true
 			}
  		case css.IdentToken: // X  hits for both a class name, and an SVG element tag, which is not needed.
-			if isAnchorClass {
+			if isClass {
 				kb.ClassNames = append(kb.ClassNames, tokenStr)
 			}
 		default:
 			// some other selector syntax
 		}
-		lastTokenStr = tokenStr
+		//lastTokenStr = tokenStr
 	}
 	return
 }

--- a/svg/style.go
+++ b/svg/style.go
@@ -7,7 +7,7 @@ import (
 type (
 	markArr [2]rune
 
-	// "Binds" an <a> element, itself wrapping a series of <text> elements, to a
+	// "Binds" a <g> or <a> element, itself wrapping a series of <text> elements, to a
 	// CSS class containing a property "goat-anchor-marks".
 	//         https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Syntax/Introduction
 	markBinding struct {

--- a/utf8/README.md
+++ b/utf8/README.md
@@ -31,7 +31,7 @@ A highly abstract view of GoAT's internal data flow, using UTF-8 text:
                                         │ │  │          │ ╰─▶UTF8-BOX ●─╯ │   SVG         │  ┌          ┐
                      ╭───────────────╮  │ ╰──┴──────────╯   ╰─────────╯   │ elements│     │  `CSS-styled`
                      │ extraction of │  │ ╭───────────────┬────────────╮  │               ├─▶`₃SVG₃file`
-                     │ CSS class-    │  ╰─▶ text positions  *<a>*and   │  │         │     │  └          ┘
+                     │ CSS class-    │  ╰─▶ text positions             │  │         │     │  └          ┘
 ┌            ┐       │ names and     │    ├╴ ─ ─ ─ ─ ─ ─ ─┤ *<text>*   ├──▶               │
 ₂ CSS files₂○─────┬──▶ *goat-anchor* ├────▶    anchor     ╷ generation │  ├ ─ ─ ─ ─ ┤     │
 └            ┘    │  │ properties    │    │   class names ╵            │  │               │
@@ -97,6 +97,9 @@ Unicode BOX characters generatable by uniline.el, but neither of AsciiFlow nor C
     ╭╮    ╭─╮
     ╰╯    │X│
           ╰─╯
+    ╭╌╌╮
+    ┊  ┊
+    ╰╌╌╯
 
 ```
 ---

--- a/utf8/_README/dataflow.bold.svg
+++ b/utf8/_README/dataflow.bold.svg
@@ -60,19 +60,19 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/utf8.css">
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }
@@ -357,7 +357,7 @@ a.svg-art:hover {
     <text x="688" y="36">i</text>
     <text x="696" y="36">o</text>
     <text x="704" y="36">n</text>
-  <a class='code'>
+  <g class='code'>
     <text x="8" y="52">a</text>
     <text x="16" y="52">n</text>
     <text x="24" y="52">n</text>
@@ -367,8 +367,8 @@ a.svg-art:hover {
     <text x="56" y="52">t</text>
     <text x="64" y="52">e</text>
     <text x="72" y="52">d</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="216" y="52">r</text>
     <text x="224" y="52">e</text>
     <text x="232" y="52">c</text>
@@ -378,8 +378,8 @@ a.svg-art:hover {
     <text x="264" y="52">r</text>
     <text x="272" y="52">e</text>
     <text x="280" y="52">d</text>
-</a>
-  <a class='code'>
+  </g>
+  <g class='code'>
     <text x="16" y="68">d</text>
     <text x="24" y="68">i</text>
     <text x="32" y="68">a</text>
@@ -388,7 +388,7 @@ a.svg-art:hover {
     <text x="56" y="68">a</text>
     <text x="64" y="68">m</text>
     <text x="72" y="68">,</text>
-</a>
+  </g>
     <text x="112" y="68">d</text>
     <text x="120" y="68">i</text>
     <text x="128" y="68">a</text>
@@ -396,7 +396,7 @@ a.svg-art:hover {
     <text x="144" y="68">r</text>
     <text x="152" y="68">a</text>
     <text x="160" y="68">m</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="224" y="68">s</text>
     <text x="232" y="68">o</text>
     <text x="240" y="68">u</text>
@@ -404,8 +404,8 @@ a.svg-art:hover {
     <text x="256" y="68">c</text>
     <text x="264" y="68">e</text>
     <text x="272" y="68">-</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="376" y="68">g</text>
     <text x="384" y="68">e</text>
     <text x="392" y="68">n</text>
@@ -413,8 +413,8 @@ a.svg-art:hover {
     <text x="408" y="68">r</text>
     <text x="416" y="68">i</text>
     <text x="424" y="68">c</text>
-</a>
-  <a class='code'>
+  </g>
+  <g class='code'>
     <text x="8" y="84">A</text>
     <text x="16" y="84">S</text>
     <text x="24" y="84">C</text>
@@ -422,7 +422,7 @@ a.svg-art:hover {
     <text x="40" y="84">I</text>
     <text x="56" y="84">o</text>
     <text x="64" y="84">r</text>
-</a>
+  </g>
     <text x="112" y="84">p</text>
     <text x="120" y="84">a</text>
     <text x="128" y="84">r</text>
@@ -430,7 +430,7 @@ a.svg-art:hover {
     <text x="144" y="84">i</text>
     <text x="152" y="84">n</text>
     <text x="160" y="84">g</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="208" y="84">i</text>
     <text x="216" y="84">n</text>
     <text x="224" y="84">d</text>
@@ -442,17 +442,17 @@ a.svg-art:hover {
     <text x="272" y="84">e</text>
     <text x="280" y="84">n</text>
     <text x="288" y="84">t</text>
-</a>
-  <a href='https://developer.mozilla.org/en-US/docs/Glossary/UTF-8' class='utf8-art'>
-  <a class='code'>
+  </g>
+  <a class='utf8-art' href='https://developer.mozilla.org/en-US/docs/Glossary/UTF-8'>
+  <g class='code'>
     <text x="24" y="100">U</text>
     <text x="32" y="100">T</text>
     <text x="40" y="100">F</text>
     <text x="48" y="100">-</text>
     <text x="56" y="100">8</text>
-</a>
-</a>
-  <a class='italic'>
+  </g>
+  </a>
+  <g class='italic'>
     <text x="216" y="100">s</text>
     <text x="224" y="100">t</text>
     <text x="232" y="100">r</text>
@@ -462,8 +462,8 @@ a.svg-art:hover {
     <text x="264" y="100">u</text>
     <text x="272" y="100">r</text>
     <text x="280" y="100">e</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="376" y="100">s</text>
     <text x="384" y="100">o</text>
     <text x="392" y="100">u</text>
@@ -471,13 +471,13 @@ a.svg-art:hover {
     <text x="408" y="100">c</text>
     <text x="416" y="100">e</text>
     <text x="424" y="100">-</text>
-</a>
+  </g>
     <text x="504" y="100">A</text>
     <text x="512" y="100">S</text>
     <text x="520" y="100">C</text>
     <text x="528" y="100">I</text>
     <text x="536" y="100">I</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="376" y="116">s</text>
     <text x="384" y="116">p</text>
     <text x="392" y="116">e</text>
@@ -486,7 +486,7 @@ a.svg-art:hover {
     <text x="416" y="116">f</text>
     <text x="424" y="116">i</text>
     <text x="432" y="116">c</text>
-</a>
+  </g>
     <text x="464" y="116">×</text>
     <text x="576" y="116">×</text>
     <text x="488" y="132">U</text>
@@ -508,7 +508,7 @@ a.svg-art:hover {
     <text x="648" y="148">n</text>
     <text x="656" y="148">t</text>
     <text x="664" y="148">s</text>
-  <a class='code'>
+  <g class='code'>
     <text x="752" y="148">C</text>
     <text x="760" y="148">S</text>
     <text x="768" y="148">S</text>
@@ -519,7 +519,7 @@ a.svg-art:hover {
     <text x="808" y="148">l</text>
     <text x="816" y="148">e</text>
     <text x="824" y="148">d</text>
-</a>
+  </g>
     <text x="184" y="164">e</text>
     <text x="192" y="164">x</text>
     <text x="200" y="164">t</text>
@@ -532,17 +532,17 @@ a.svg-art:hover {
     <text x="256" y="164">n</text>
     <text x="272" y="164">o</text>
     <text x="280" y="164">f</text>
-  <a class='code'>
-  <a href='https://developer.mozilla.org/en-US/docs/Web/SVG' class='svg-art'>
+  <g class='code'>
+  <a class='svg-art' href='https://developer.mozilla.org/en-US/docs/Web/SVG'>
     <text x="760" y="164">S</text>
     <text x="768" y="164">V</text>
     <text x="776" y="164">G</text>
-</a>
+  </a>
     <text x="792" y="164">f</text>
     <text x="800" y="164">i</text>
     <text x="808" y="164">l</text>
     <text x="816" y="164">e</text>
-</a>
+  </g>
     <text x="184" y="180">C</text>
     <text x="192" y="180">S</text>
     <text x="200" y="180">S</text>
@@ -565,14 +565,6 @@ a.svg-art:hover {
     <text x="440" y="180">o</text>
     <text x="448" y="180">n</text>
     <text x="456" y="180">s</text>
-  <a class='bold'>
-    <text x="488" y="180">&lt;</text>
-    <text x="496" y="180">a</text>
-    <text x="504" y="180">&gt;</text>
-</a>
-    <text x="520" y="180">a</text>
-    <text x="528" y="180">n</text>
-    <text x="536" y="180">d</text>
     <text x="184" y="196">n</text>
     <text x="192" y="196">a</text>
     <text x="200" y="196">m</text>
@@ -581,15 +573,15 @@ a.svg-art:hover {
     <text x="232" y="196">a</text>
     <text x="240" y="196">n</text>
     <text x="248" y="196">d</text>
-  <a class='bold'>
+  <g class='bold'>
     <text x="488" y="196">&lt;</text>
     <text x="496" y="196">t</text>
     <text x="504" y="196">e</text>
     <text x="512" y="196">x</text>
     <text x="520" y="196">t</text>
     <text x="528" y="196">&gt;</text>
-</a>
-  <a href='https://developer.mozilla.org/en-US/docs/Web/CSS' class='css-art'>
+  </g>
+  <a class='css-art' href='https://developer.mozilla.org/en-US/docs/Web/CSS'>
     <text x="16" y="212">C</text>
     <text x="24" y="212">S</text>
     <text x="32" y="212">S</text>
@@ -598,8 +590,8 @@ a.svg-art:hover {
     <text x="64" y="212">l</text>
     <text x="72" y="212">e</text>
     <text x="80" y="212">s</text>
-</a>
-  <a class='bold'>
+  </a>
+  <g class='bold'>
     <text x="192" y="212">g</text>
     <text x="200" y="212">o</text>
     <text x="208" y="212">a</text>
@@ -611,7 +603,7 @@ a.svg-art:hover {
     <text x="256" y="212">h</text>
     <text x="264" y="212">o</text>
     <text x="272" y="212">r</text>
-</a>
+  </g>
     <text x="376" y="212">a</text>
     <text x="384" y="212">n</text>
     <text x="392" y="212">c</text>

--- a/utf8/_README/dataflow.earth.svg
+++ b/utf8/_README/dataflow.earth.svg
@@ -60,19 +60,19 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/utf8.css">
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }
@@ -357,7 +357,7 @@ a.svg-art:hover {
     <text x="688" y="36">i</text>
     <text x="696" y="36">o</text>
     <text x="704" y="36">n</text>
-  <a class='code'>
+  <g class='code'>
     <text x="8" y="52">a</text>
     <text x="16" y="52">n</text>
     <text x="24" y="52">n</text>
@@ -367,8 +367,8 @@ a.svg-art:hover {
     <text x="56" y="52">t</text>
     <text x="64" y="52">e</text>
     <text x="72" y="52">d</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="216" y="52">r</text>
     <text x="224" y="52">e</text>
     <text x="232" y="52">c</text>
@@ -378,8 +378,8 @@ a.svg-art:hover {
     <text x="264" y="52">r</text>
     <text x="272" y="52">e</text>
     <text x="280" y="52">d</text>
-</a>
-  <a class='code'>
+  </g>
+  <g class='code'>
     <text x="16" y="68">d</text>
     <text x="24" y="68">i</text>
     <text x="32" y="68">a</text>
@@ -388,7 +388,7 @@ a.svg-art:hover {
     <text x="56" y="68">a</text>
     <text x="64" y="68">m</text>
     <text x="72" y="68">,</text>
-</a>
+  </g>
     <text x="112" y="68">d</text>
     <text x="120" y="68">i</text>
     <text x="128" y="68">a</text>
@@ -396,7 +396,7 @@ a.svg-art:hover {
     <text x="144" y="68">r</text>
     <text x="152" y="68">a</text>
     <text x="160" y="68">m</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="224" y="68">s</text>
     <text x="232" y="68">o</text>
     <text x="240" y="68">u</text>
@@ -404,8 +404,8 @@ a.svg-art:hover {
     <text x="256" y="68">c</text>
     <text x="264" y="68">e</text>
     <text x="272" y="68">-</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="376" y="68">g</text>
     <text x="384" y="68">e</text>
     <text x="392" y="68">n</text>
@@ -413,8 +413,8 @@ a.svg-art:hover {
     <text x="408" y="68">r</text>
     <text x="416" y="68">i</text>
     <text x="424" y="68">c</text>
-</a>
-  <a class='code'>
+  </g>
+  <g class='code'>
     <text x="8" y="84">A</text>
     <text x="16" y="84">S</text>
     <text x="24" y="84">C</text>
@@ -422,7 +422,7 @@ a.svg-art:hover {
     <text x="40" y="84">I</text>
     <text x="56" y="84">o</text>
     <text x="64" y="84">r</text>
-</a>
+  </g>
     <text x="112" y="84">p</text>
     <text x="120" y="84">a</text>
     <text x="128" y="84">r</text>
@@ -430,7 +430,7 @@ a.svg-art:hover {
     <text x="144" y="84">i</text>
     <text x="152" y="84">n</text>
     <text x="160" y="84">g</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="208" y="84">i</text>
     <text x="216" y="84">n</text>
     <text x="224" y="84">d</text>
@@ -442,17 +442,17 @@ a.svg-art:hover {
     <text x="272" y="84">e</text>
     <text x="280" y="84">n</text>
     <text x="288" y="84">t</text>
-</a>
-  <a href='https://developer.mozilla.org/en-US/docs/Glossary/UTF-8' class='utf8-art'>
-  <a class='code'>
+  </g>
+  <a class='utf8-art' href='https://developer.mozilla.org/en-US/docs/Glossary/UTF-8'>
+  <g class='code'>
     <text x="24" y="100">U</text>
     <text x="32" y="100">T</text>
     <text x="40" y="100">F</text>
     <text x="48" y="100">-</text>
     <text x="56" y="100">8</text>
-</a>
-</a>
-  <a class='italic'>
+  </g>
+  </a>
+  <g class='italic'>
     <text x="216" y="100">s</text>
     <text x="224" y="100">t</text>
     <text x="232" y="100">r</text>
@@ -462,8 +462,8 @@ a.svg-art:hover {
     <text x="264" y="100">u</text>
     <text x="272" y="100">r</text>
     <text x="280" y="100">e</text>
-</a>
-  <a class='italic'>
+  </g>
+  <g class='italic'>
     <text x="376" y="100">s</text>
     <text x="384" y="100">o</text>
     <text x="392" y="100">u</text>
@@ -471,13 +471,13 @@ a.svg-art:hover {
     <text x="408" y="100">c</text>
     <text x="416" y="100">e</text>
     <text x="424" y="100">-</text>
-</a>
+  </g>
     <text x="504" y="100">A</text>
     <text x="512" y="100">S</text>
     <text x="520" y="100">C</text>
     <text x="528" y="100">I</text>
     <text x="536" y="100">I</text>
-  <a class='italic'>
+  <g class='italic'>
     <text x="376" y="116">s</text>
     <text x="384" y="116">p</text>
     <text x="392" y="116">e</text>
@@ -486,7 +486,7 @@ a.svg-art:hover {
     <text x="416" y="116">f</text>
     <text x="424" y="116">i</text>
     <text x="432" y="116">c</text>
-</a>
+  </g>
     <text x="464" y="116">×</text>
     <text x="576" y="116">×</text>
     <text x="488" y="132">U</text>
@@ -508,7 +508,7 @@ a.svg-art:hover {
     <text x="648" y="148">n</text>
     <text x="656" y="148">t</text>
     <text x="664" y="148">s</text>
-  <a class='code'>
+  <g class='code'>
     <text x="752" y="148">C</text>
     <text x="760" y="148">S</text>
     <text x="768" y="148">S</text>
@@ -519,7 +519,7 @@ a.svg-art:hover {
     <text x="808" y="148">l</text>
     <text x="816" y="148">e</text>
     <text x="824" y="148">d</text>
-</a>
+  </g>
     <text x="184" y="164">e</text>
     <text x="192" y="164">x</text>
     <text x="200" y="164">t</text>
@@ -532,17 +532,17 @@ a.svg-art:hover {
     <text x="256" y="164">n</text>
     <text x="272" y="164">o</text>
     <text x="280" y="164">f</text>
-  <a class='code'>
-  <a href='https://developer.mozilla.org/en-US/docs/Web/SVG' class='svg-art'>
+  <g class='code'>
+  <a class='svg-art' href='https://developer.mozilla.org/en-US/docs/Web/SVG'>
     <text x="760" y="164">S</text>
     <text x="768" y="164">V</text>
     <text x="776" y="164">G</text>
-</a>
+  </a>
     <text x="792" y="164">f</text>
     <text x="800" y="164">i</text>
     <text x="808" y="164">l</text>
     <text x="816" y="164">e</text>
-</a>
+  </g>
     <text x="184" y="180">C</text>
     <text x="192" y="180">S</text>
     <text x="200" y="180">S</text>
@@ -565,14 +565,6 @@ a.svg-art:hover {
     <text x="440" y="180">o</text>
     <text x="448" y="180">n</text>
     <text x="456" y="180">s</text>
-  <a class='bold'>
-    <text x="488" y="180">&lt;</text>
-    <text x="496" y="180">a</text>
-    <text x="504" y="180">&gt;</text>
-</a>
-    <text x="520" y="180">a</text>
-    <text x="528" y="180">n</text>
-    <text x="536" y="180">d</text>
     <text x="184" y="196">n</text>
     <text x="192" y="196">a</text>
     <text x="200" y="196">m</text>
@@ -581,15 +573,15 @@ a.svg-art:hover {
     <text x="232" y="196">a</text>
     <text x="240" y="196">n</text>
     <text x="248" y="196">d</text>
-  <a class='bold'>
+  <g class='bold'>
     <text x="488" y="196">&lt;</text>
     <text x="496" y="196">t</text>
     <text x="504" y="196">e</text>
     <text x="512" y="196">x</text>
     <text x="520" y="196">t</text>
     <text x="528" y="196">&gt;</text>
-</a>
-  <a href='https://developer.mozilla.org/en-US/docs/Web/CSS' class='css-art'>
+  </g>
+  <a class='css-art' href='https://developer.mozilla.org/en-US/docs/Web/CSS'>
     <text x="16" y="212">C</text>
     <text x="24" y="212">S</text>
     <text x="32" y="212">S</text>
@@ -598,8 +590,8 @@ a.svg-art:hover {
     <text x="64" y="212">l</text>
     <text x="72" y="212">e</text>
     <text x="80" y="212">s</text>
-</a>
-  <a class='bold'>
+  </a>
+  <g class='bold'>
     <text x="192" y="212">g</text>
     <text x="200" y="212">o</text>
     <text x="208" y="212">a</text>
@@ -611,7 +603,7 @@ a.svg-art:hover {
     <text x="256" y="212">h</text>
     <text x="264" y="212">o</text>
     <text x="272" y="212">r</text>
-</a>
+  </g>
     <text x="376" y="212">a</text>
     <text x="384" y="212">n</text>
     <text x="392" y="212">c</text>

--- a/utf8/_README/dataflow.utf8.txt
+++ b/utf8/_README/dataflow.utf8.txt
@@ -9,7 +9,7 @@
                                         │ │  │          │ ╰─▶UTF8-BOX ●─╯ │   SVG         │  ┌          ┐
                      ╭───────────────╮  │ ╰──┴──────────╯   ╰─────────╯   │ elements│     │  `CSS-styled`
                      │ extraction of │  │ ╭───────────────┬────────────╮  │               ├─▶`₃SVG₃file`
-                     │ CSS class-    │  ╰─▶ text positions  *<a>*and   │  │         │     │  └          ┘
+                     │ CSS class-    │  ╰─▶ text positions             │  │         │     │  └          ┘
 ┌            ┐       │ names and     │    ├╴ ─ ─ ─ ─ ─ ─ ─┤ *<text>*   ├──▶               │
 ₂ CSS files₂○─────┬──▶ *goat-anchor* ├────▶    anchor     ╷ generation │  ├ ─ ─ ─ ─ ┤     │
 └            ┘    │  │ properties    │    │   class names ╵            │  │               │

--- a/utf8/_README/hello-world.href.css
+++ b/utf8/_README/hello-world.href.css
@@ -1,4 +1,4 @@
-a.underline_href {
+.underline_href {
     goat-anchor-marks: "__";
     goat-anchor-href: "https://www.worldometers.info/";
 }

--- a/utf8/_README/hello-world.href.svg
+++ b/utf8/_README/hello-world.href.svg
@@ -60,25 +60,25 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/utf8.css">
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }
   </style>
   <style type="text/css" source-text-origin="./utf8/_README/hello-world.href.css">
-a.underline_href {
+.underline_href {
     goat-anchor-marks: "__";
     goat-anchor-href: "https://www.worldometers.info/";
 }
@@ -107,21 +107,21 @@ a.underline_href {
     <circle cx="192" cy="16" r="4" class="filled"></circle>
   </g>
   <g id='text'>
-  <a class='italic'>
+  <g class='italic'>
     <text x="64" y="20">H</text>
     <text x="72" y="20">e</text>
     <text x="80" y="20">l</text>
     <text x="88" y="20">l</text>
     <text x="96" y="20">o</text>
     <text x="104" y="20">,</text>
-  <a href='https://www.worldometers.info/' class='underline underline_href'>
+  <a class='underline underline_href' href='https://www.worldometers.info/'>
     <text x="120" y="20">w</text>
     <text x="128" y="20">o</text>
     <text x="136" y="20">r</text>
     <text x="144" y="20">l</text>
     <text x="152" y="20">d</text>
-</a>
-</a>
+  </a>
+  </g>
   </g>
 </g>
 </svg>

--- a/utf8/_README/hello-world.styled.svg
+++ b/utf8/_README/hello-world.styled.svg
@@ -60,19 +60,19 @@ svg {
 }
   </style>
   <style type="text/css" source-text-origin="embed:style/utf8.css">
-a.bold {
+.bold {
     goat-anchor-marks: "**";
     font-weight: bold;
 }
-a.italic {
+.italic {
     goat-anchor-marks: "//";
     font-style: italic;
 }
-a.underline {
+.underline {
     goat-anchor-marks: "__";
     text-decoration: underline;
 }
-a.code {
+.code {
     goat-anchor-marks: "``";
     stroke: inherit;
 }
@@ -101,21 +101,21 @@ a.code {
     <circle cx="192" cy="16" r="4" class="filled"></circle>
   </g>
   <g id='text'>
-  <a class='italic'>
+  <g class='italic'>
     <text x="64" y="20">H</text>
     <text x="72" y="20">e</text>
     <text x="80" y="20">l</text>
     <text x="88" y="20">l</text>
     <text x="96" y="20">o</text>
     <text x="104" y="20">,</text>
-  <a class='underline'>
+  <g class='underline'>
     <text x="120" y="20">w</text>
     <text x="128" y="20">o</text>
     <text x="136" y="20">r</text>
     <text x="144" y="20">l</text>
     <text x="152" y="20">d</text>
-</a>
-</a>
+  </g>
+  </g>
   </g>
 </g>
 </svg>

--- a/utf8/examples/uniline.svg
+++ b/utf8/examples/uniline.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
-    width="696" height="90"
-    viewBox="0 0 696 90">
+    width="696" height="138"
+    viewBox="0 0 696 138">
   <style type="text/css" source-text-origin="source-independent defaults: shared by ASCII and UTF-8">
     svg {
         color-scheme: light dark; /* this becomes necessary if not inherited from parent elements */
@@ -52,7 +52,11 @@
 <g transform='translate(8,12)'>
   <g id='lines-vertical'>
     <polyline class="path" points="32,36 32,44"/>
+    <polyline class="path" points="32,84 32,88"/>
+    <polyline class="path" points="32,104 32,108"/>
     <polyline class="path" points="40,36 40,44"/>
+    <polyline class="path" points="56,84 56,88"/>
+    <polyline class="path" points="56,104 56,108"/>
     <polyline class="path" points="80,36 80,60"/>
     <polyline class="path" points="96,36 96,60"/>
   </g>
@@ -71,6 +75,10 @@
     <path class="path" d="M 40,44 A 4,4 0 0,1 36,48"></path>
     <path class="path" d="M 80,60 A 4,4 0 0,0 84,64"></path>
     <path class="path" d="M 96,60 A 4,4 0 0,1 92,64"></path>
+    <path class="path" d="M 36,80 A 4,4 0 0,0 32,84"></path>
+    <path class="path" d="M 52,80 A 4,4 0 0,1 56,84"></path>
+    <path class="path" d="M 32,108 A 4,4 0 0,0 36,112"></path>
+    <path class="path" d="M 56,108 A 4,4 0 0,1 52,112"></path>
   </g>
   <g id='circles'>
   </g>
@@ -151,6 +159,12 @@
     <text x="672" y="4">i</text>
     <text x="680" y="4">:</text>
     <text x="88" y="52">X</text>
+    <text x="40" y="84">╌</text>
+    <text x="48" y="84">╌</text>
+    <text x="32" y="100">┊</text>
+    <text x="56" y="100">┊</text>
+    <text x="40" y="116">╌</text>
+    <text x="48" y="116">╌</text>
   </g>
 </g>
 </svg>

--- a/utf8/examples/uniline.txt
+++ b/utf8/examples/uniline.txt
@@ -3,3 +3,6 @@ Unicode BOX characters generatable by uniline.el, but neither of AsciiFlow nor C
     ╭╮    ╭─╮
     ╰╯    │X│
           ╰─╯
+    ╭╌╌╮
+    ┊  ┊
+    ╰╌╌╯


### PR DESCRIPTION
Firefox tolerates nested SVG <a> elements; other browsers do not.

Fixes #48.
